### PR TITLE
sniffer: fix segfault in dtor()

### DIFF
--- a/src/core/sniffer.cc
+++ b/src/core/sniffer.cc
@@ -42,7 +42,8 @@ Sniffer::Sniffer(const char* iface_name, SnifferType type, size_t bridge_id,
 
 Sniffer::~Sniffer()
 {
-    pcap_close(handle);
+    if ( handle )
+        pcap_close(handle);
 }
 
 bool Sniffer::open_live()


### PR DESCRIPTION
sniffer: add check on nullptr for handle before call pcap_close() in Sniffer::dtor()